### PR TITLE
fix: compat  c++17 compilation

### DIFF
--- a/src/bb.cpp
+++ b/src/bb.cpp
@@ -50,6 +50,15 @@ namespace {
 
    using khi::BB_Bucket;
 
+#if __cplusplus > 201402L
+   struct find_name {
+      std::string name;
+      find_name(const std::string& value) : name(value) {}
+      constexpr bool operator()(const BB_Bucket& b) const {
+         return b.name == name;
+      }
+   };
+#else
    struct find_name : std::unary_function<BB_Bucket, bool> {
       std::string name;
       find_name(const std::string& value) : name(value) {}
@@ -57,6 +66,7 @@ namespace {
          return b.name == name;
       }
    };
+#endif //  __cplusplus > 201402L
 
    using khi::Json;
    using khi::ResponseError;

--- a/src/command.h
+++ b/src/command.h
@@ -69,14 +69,25 @@ struct Base {
 
    int parseOrDefault(const std::string& number, int def) const;
 
-   struct PrintObject : public std::unary_function<BB_Object, void> { 
+#if __cplusplus > 201402L
+   struct PrintObject {
       const Base& m_command;
       PrintObject(const Base& command) : m_command(command) {
       }
-      void operator()(const BB_Object& file) const { 
+      constexpr void operator()(const BB_Object& file) const {
          m_command.printObject(file);
-      } 
+      }
    };
+#else
+   struct PrintObject : public std::unary_function<BB_Object, void> {
+      const Base& m_command;
+      PrintObject(const Base& command) : m_command(command) {
+      }
+      void operator()(const BB_Object& file) const {
+         m_command.printObject(file);
+      }
+   };
+#endif // __cplusplus > 201402L
 
    friend struct PrintObject;
 };


### PR DESCRIPTION
**DESCRIPTION**

Clang 16 defaults to c++17 mode. This change allows blazer to compile with Clang 16 and other compilers that default to c++17 mode without having to setup configuration for the autotools suite.